### PR TITLE
Added `left` rule

### DIFF
--- a/lite-vimeo.ts
+++ b/lite-vimeo.ts
@@ -133,6 +133,7 @@ export class LiteVimeoEmbed extends HTMLElement {
           position: absolute;
           width: 100%;
           height: 100%;
+          left: 0;
         }
 
         #frame {


### PR DESCRIPTION
Without the `left` rule on the poster image the image will be placed at the center, which is the equivalent of a `left: 50%`.

This breaks the layout on mobile resolutions.