### PR TITLE
Add support for videos with unlisted privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import '@slightlyoff/lite-vimeo';
 If you want the paste-and-go version, you can simply load it via CDN:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@slightlyoff/lite-vimeo@0.1.1/lite-vimeo.js">
+<script type="module" src="https://cdn.jsdelivr.net/npm/@slightlyoff/lite-vimeo@0.1.2/lite-vimeo.js">
 ```
 
 ## Basic Usage
@@ -107,6 +107,14 @@ Uses Intersection Observer if available to automatically load the Vimeo iframe w
 <lite-vimeo videoid="364402896" autoload autoplay></lite-vimeo>
 ```
 
+## Play Unlisted Videos
+
+Accepts a `videohash` attribute that corresponds to Vimeo's `h` parameter for [unlisted videos](https://help.vimeo.com/hc/en-us/articles/12426199699985-Overview-of-video-privacy-settings#h_01FK121EGDV30KZV4232TNZPPS).
+
+```html
+<lite-vimeo videoid="981374828" videohash="208f5ff18e"></lite-vimeo>
+```
+
 ## Attributes
 
 The web component allows certain attributes to be give a little additional
@@ -114,9 +122,10 @@ flexibility.
 
 | Name         | Description                                                      | Default |
 | ------------ | ---------------------------------------------------------------- | ------- |
-| `videoid`    | The Vimeo videoid                                              | ``      |
+| `videoid`    | The Vimeo videoid                                                | ``      |
 | `videotitle` | The title of the video                                           | `Video` |
 | `videoplay`  | The title of the play button (for translation)                   | `Play`  |
 | `autoload`   | Use Intersection Observer to load iframe when scrolled into view | `false` |
 | `autoplay`   | Video attempts to play automatically if auto-load set and browser allows it | `false` |
 | `start`      | Set the point at which the video should start, in seconds        | `0`     |
+| `videohash`  | The privacy hash (for an unlisted video)                         | ``      |

--- a/lite-vimeo.ts
+++ b/lite-vimeo.ts
@@ -3,7 +3,7 @@
  * The shadowDom / Intersection Observer version of Paul's concept:
  * https://github.com/paulirish/lite-youtube-embed
  *
- * A lightweight YouTube embed. Still should feel the same to the user, just
+ * A lightweight Vimeo embed. Still should feel the same to the user, just
  * MUCH faster to initialize and paint.
  *
  * Thx to these as the inspiration
@@ -82,11 +82,11 @@ export class LiteVimeoEmbed extends HTMLElement {
   }
 
   get videoStartAt(): string {
-    return this.getAttribute('videoPlay') || '0s';
+    return this.getAttribute('start') || '0s';
   }
 
   set videoStartAt(time: string) {
-    this.setAttribute('videoPlay', time);
+    this.setAttribute('start', time);
   }
 
   get autoLoad(): boolean {
@@ -113,6 +113,13 @@ export class LiteVimeoEmbed extends HTMLElement {
     }
   }
 
+  get videoHash(): string {
+    return encodeURIComponent(this.getAttribute('videohash') || '');
+  }
+
+  set videoHash(hash: string) {
+    this.setAttribute('videohash', hash);
+  }
 
   /**
    * Define our shadowDOM for the component
@@ -288,15 +295,20 @@ export class LiteVimeoEmbed extends HTMLElement {
        *    allow="autoplay; fullscreen" allowfullscreen>
        *  </iframe>
        */
-      // FIXME: add a setting for autoplay
-      const apValue = ((this.autoLoad && this.autoPlay) || (!this.autoLoad)) ?
-                        "autoplay=1" : "";
-      const srcUrl = new URL(
-        `/video/${this.videoId}?${apValue}&#t=${this.videoStartAt}`,
-        "https://player.vimeo.com/"
-      );
+      const srcUrl = new URL(`https://player.vimeo.com/video/${this.videoId}`);
 
-      // TODO: construct src value w/ URL constructor
+      if (this.autoLoad && this.autoPlay) {
+        srcUrl.searchParams.set('autoplay', '1');
+      }
+
+      if (this.videoHash) {
+        srcUrl.searchParams.set('h', this.videoHash);
+      }
+
+      if (this.videoStartAt) {
+        srcUrl.hash = `t=${this.videoStartAt}`;
+      }
+
       const iframeHTML = `
 <iframe frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
👋🏾  I'm an engineer on the Player team at Vimeo. We saw an [instance](https://www.reddit.com/r/videos/comments/1lalt1o/tesla_fsd_ignoring_school_bus_stop_signs_to_run/) of lite-vimeo out in the wild recently and realized that it hadn't been updated to support videos with the unlisted privacy, such as [this one](https://player.vimeo.com/video/981374828?h=208f5ff18e), so we wanted to submit a patch:

```
<lite-vimeo videoid="981374828" videohash="208f5ff18e"></lite-vimeo>
```